### PR TITLE
feat(stack): implement stack using linked list

### DIFF
--- a/src/stack-linked-list-based/stack-linked-list-based.test.ts
+++ b/src/stack-linked-list-based/stack-linked-list-based.test.ts
@@ -1,0 +1,76 @@
+import { Stack } from "./stack-linked-list-based";
+
+describe("Stack LinkedList Based FILO", () => {
+  describe("push", () => {
+    it("should push data to the stack", () => {
+      const stk = new Stack<number>(1, 2, 3, 4);
+
+      stk.push(5);
+
+      const peek = stk.peek();
+
+      expect(peek).toBe(5);
+      expect(stk.size).toBe(5);
+    });
+  });
+  describe("pop", () => {
+    it("should return null if the stack is empty", () => {
+      const stk = new Stack<number>();
+
+      const pop = stk.pop();
+
+      expect(pop).toBeNull();
+    });
+    it("should remove the last pushed element from the stack and return it", () => {
+      const stk = new Stack<number>(1, 2, 3, 4);
+
+      expect(stk.size).toBe(4);
+
+      const pop = stk.pop();
+
+      expect(pop).toBe(4);
+      expect(stk.size).toBe(3);
+    });
+    it("should return last element on the stack and stack become empty", () => {
+      const stk = new Stack<number>(1);
+
+      expect(stk.size).toBe(1);
+
+      const pop = stk.pop();
+
+      expect(pop).toBe(1);
+      expect(stk.size).toBe(0);
+      expect(stk.hasData()).toBe(false);
+    });
+  });
+  describe("peek", () => {
+    it("should return null if the stack is empty", () => {
+      const stk = new Stack<number>();
+
+      const peek = stk.peek();
+
+      expect(peek).toBeNull();
+    });
+    it("should return the last pushed element on the stack", () => {
+      const stk = new Stack<number>(1, 2, 3);
+
+      const peek = stk.peek();
+
+      expect(peek).toBe(3);
+    });
+  });
+  describe("hasData", () => {
+    it("should return false if the stack is empty", () => {
+      const stk = new Stack<number>();
+
+      const boolVal = stk.hasData();
+      expect(boolVal).toBe(false);
+    });
+    it("should return true if stack still have data", () => {
+      const stk = new Stack<number>(1, 2, 3);
+
+      const boolVal = stk.hasData();
+      expect(boolVal).toBe(true);
+    });
+  });
+});

--- a/src/stack-linked-list-based/stack-linked-list-based.ts
+++ b/src/stack-linked-list-based/stack-linked-list-based.ts
@@ -1,0 +1,32 @@
+import { LinkedList } from "../linkedlist/linked-list";
+
+export class Stack<T> {
+  #dataList: LinkedList<T>;
+  constructor(...args: T[]) {
+    const reversedArgs = args.reverse();
+    this.#dataList = new LinkedList<T>(...reversedArgs);
+  }
+
+  push(_data: T): void {
+    this.#dataList.insertFirst(_data);
+  }
+
+  pop(): T | null {
+    const data = this.#dataList.head?.data ?? null;
+    this.#dataList.deleteHead();
+
+    return data;
+  }
+
+  peek(): T | null {
+    return this.#dataList.head?.data ?? null;
+  }
+
+  hasData(): boolean {
+    return this.#dataList.size > 0;
+  }
+
+  get size() {
+    return this.#dataList.size;
+  }
+}


### PR DESCRIPTION
### 📦 Summary

This pull request introduces a `Stack<T>` implementation built on top of the existing `LinkedList<T>` data structure.

The stack follows LIFO (Last In, First Out) semantics and supports standard stack operations with constant-time complexity.

---

### ✅ Features

- **push(data)** – Adds a new item to the top of the stack
- **pop()** – Removes and returns the top item; returns `null` if empty
- **peek()** – Returns the top item without removing it
- **hasData()** – Returns `true` if the stack has any items
- **size** – Getter for current stack size

---

### 🧪 Implementation Notes

- Internally uses `LinkedList<T>` with `insertFirst()` and `deleteHead()` to maintain O(1) push/pop performance
- Constructor accepts variadic arguments (spread syntax) and reverses them to maintain correct stack order

---

### ✅ Testing

- All methods are covered by unit tests using Jest
- Edge cases such as popping from an empty stack are handled gracefully

---

### 📌 Next Steps

- Consider adding an iterator for the stack if needed in the future
- Queue implementation may reuse similar patterns with `LinkedList<T>`

