### PR TITLE
feat(queue): implement queue using linked list

### DIFF
--- a/src/queue-linked-list-based/queue-linked-list-based.test.ts
+++ b/src/queue-linked-list-based/queue-linked-list-based.test.ts
@@ -1,0 +1,59 @@
+import { Queue } from "./queue-linked-list-based";
+
+describe("Queue Linked List Based", () => {
+  describe("enqueue", () => {
+    it("should push new data to the queue", () => {
+      const q = new Queue<number>();
+
+      q.enqueue(1);
+
+      expect(q.size).toBe(1);
+      expect(q.peek()).toBe(1);
+    });
+  });
+
+  describe("dequeue", () => {
+    it("should return null if the queue is empty", () => {
+      const q = new Queue<number>();
+
+      const data = q.dequeue();
+
+      expect(data).toBeNull();
+      expect(q.size).toBe(0);
+      expect(q.peek()).toBeNull();
+    });
+    it("should remove data from the queue and return its value", () => {
+      const q = new Queue<number>(1, 2, 3);
+
+      const data = q.dequeue();
+
+      expect(data).toBe(1);
+      expect(q.size).toBe(2);
+      expect(q.peek()).toBe(2);
+    });
+  });
+
+  describe("peek", () => {
+    it("shoud return the value of the first item of the queue without removing it", () => {
+      const q = new Queue<number>(1, 2, 3);
+
+      const data = q.peek();
+
+      expect(data).toBe(1);
+      expect(q.size).toBe(3);
+    });
+  });
+
+  describe("hasData", () => {
+    it("should return false if queue is empty", () => {
+      const q = new Queue<number>();
+
+      expect(q.hasData()).toBe(false);
+    });
+    it("should return true if queue has atleast one value", () => {
+      const q = new Queue<number>(1);
+
+      expect(q.hasData()).toBe(true);
+    });
+  });
+});

--- a/src/queue-linked-list-based/queue-linked-list-based.ts
+++ b/src/queue-linked-list-based/queue-linked-list-based.ts
@@ -1,0 +1,26 @@
+import { LinkedList } from "../linkedlist/linked-list";
+
+export class Queue<T> {
+  #dataList: LinkedList<T>;
+  constructor(...args: T[]) {
+    this.#dataList = new LinkedList<T>(...args);
+  }
+
+  enqueue(_data: T): void {
+    this.#dataList.insertLast(_data);
+  }
+  dequeue(): T | null {
+    const data = this.#dataList.head?.data ?? null;
+    this.#dataList.deleteHead();
+    return data;
+  }
+  peek(): T | null {
+    return this.#dataList.head?.data ?? null;
+  }
+  hasData(): boolean {
+    return this.#dataList.size > 0;
+  }
+  get size() {
+    return this.#dataList.size;
+  }
+}


### PR DESCRIPTION
### 📦 Summary

This pull request adds a generic `Queue<T>` implementation built on top of the existing `LinkedList<T>`. The queue follows FIFO (First In, First Out) semantics and provides standard queue operations with efficient performance.

---

### ✅ Features

- **enqueue(data)** – Adds an item to the back of the queue
- **dequeue()** – Removes and returns the item at the front of the queue (`null` if empty)
- **peek()** – Returns the item at the front without removing it
- **hasData()** – Returns `true` if the queue has any items
- **size** – Getter for the current number of items in the queue

---

### 🧪 Implementation Notes

- Internally uses `LinkedList<T>` with `insertLast()` and `deleteHead()` for efficient enqueue/dequeue operations
- Constructor supports variadic arguments (`...args`) to initialize the queue
- All operations handle empty-state cases safely and return `null` when appropriate

---

### ✅ Testing

- Full Jest test coverage for:
  - Basic enqueue/dequeue behavior
  - Empty queue behavior
  - Initialization via constructor
  - Correct size tracking and data order

---

### 📌 Next Steps

- Consider implementing an array-based queue as an alternative
